### PR TITLE
Update pointers after rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ With [`cookiecutter` installed](https://cookiecutter.readthedocs.io/en/latest/in
 execute the following command inside the folder you want to create the skeletal repository. 
 
 ```bash
-cookiecutter gh:choderalab/cookiecutter-python-comp-chem
+cookiecutter gh:choderalab/cookiecutter-compchem
 ```
 
 Which fetches this repository from github automatically and prompts the user for some simple information such as 


### PR DESCRIPTION
Repo has been renamed `cookiecutter-compchem` and the instructions in this file have changed.

Please update your git pointers to

```bash
git remote set-url origin git@github.com:choderalab/cookiecutter-compchem
```

`https` syntax is a bit different.

Fixes #1