### PR TITLE
Docs and versioner integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,38 @@ cookiecutter gh:choderalab/cookiecutter-compchem
 Which fetches this repository from github automatically and prompts the user for some simple information such as 
 package name, author(s), and licences. 
 
+## Next steps and web integrations
+The repository contains a number of "hooks" that integrate with a variety of web services. To fully integrate the project
+with these web services and to get started developing your project please proceed through the following directions.
+
+### Local installation
+For development work it is often recommended to do a "local" python install via `pip install -e .`. This command will insert your
+new project into your Python site-packages folder so that it can be found in any directory on your computer.
+
+### Setting up with GitHub
+...
+
+### Testing
+The Python testing framework was chosen to be [pytest](https://pytest.org) for this project. Other testing frameworks are available;
+however, the authors believe the combination of easy [parametrization of tests](https://docs.pytest.org/en/latest/parametrize.html),
+[fixtures](https://docs.pytest.org/en/latest/fixture.html), and [test marking](https://docs.pytest.org/en/latest/example/markers.html)
+make `pytest` particularly suited for computational chemistry.
+
+To get started additional tests can be added to the `project/tests/` folder. Any function starting with `test_*` will automatically be
+included in the testing framework. While these can be added in anywhere in your directory structure, it is highly recommended to keep them
+contained within the `project/tests/` folder.
+
+Tests can be run with the `py.test -v` command. There are a number of additional command line arguments to [explore](https://docs.pytest.org/en/latest/usage.html).
+
+### Continuous Integration
+Testing is accomplished with both [Appveyor](https://www.appveyor.com) (for Windows testing) and [Travis-CI](https://travis-ci.org) (for Linux testing). These frameworks are chosen as they
+are completely free for open source projects and allow you to automatically verify that your project works under a variety of OS's and
+Python versions. To begin please register with both Appveyor and Travis-CI and turn on the git hooks under the project tabs.
+
+### Documentation 
+Make a [ReadTheDocs](https://readthedocs.org) account and turn on the git hook...
+
+
 ## Output Skeleton
 
 This will be the skeleton made by this `cookiecutter`, the items marked in `{{ }}` will be replaced by your choices 

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/__init__.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/__init__.py
@@ -7,4 +7,12 @@
 # Safe to remove with Python 3-only code
 from __future__ import absolute_import
 
+# Add imports here
 from .{{cookiecutter.first_module_name}} import *
+
+# Handle versioneer
+from ._version import get_versions
+versions = get_versions()
+__version__ = versions['version']
+__git_revision__ = versions['full-revisionid']
+del get_versions, versions

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/data/README.md
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/data/README.md
@@ -5,7 +5,7 @@ This is a place where non-code related additional information (such as data file
 go that you want to ship alongside your code.
 
 Please note that it is not recommended to place large files in your git directory. If your project requires files larger
-than a few megabytes in size it is recommended to host these files elsewhere. This is especially true as for binary files
+than a few megabytes in size it is recommended to host these files elsewhere. This is especially true for binary files
 as the `git` structure is unable to correctly take updates to these files and will store a complete copy of every version
 in your `git` history which can quickly add up. As a note most `git` hosting services like GitHub have a 1 GB per repository
 cap.

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/data/README.md
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/data/README.md
@@ -4,6 +4,12 @@ This directory contains sample additional data you may want to include with your
 This is a place where non-code related additional information (such as data files, molecular structures,  etc.) can 
 go that you want to ship alongside your code.
 
+Please note that it is not recommended to place large files in your git directory. If your project requires files larger
+than a few megabytes in size it is recommended to host these files elsewhere. This is especially true as for binary files
+as the `git` structure is unable to correctly take updates to these files and will store a complete copy of every version
+in your `git` history which can quickly add up. As a note most `git` hosting services like GitHub have a 1 GB per repository
+cap.
+
 ## Including package data
 
 Modify your package's `setup.py` file and the `setup()` command. Include the 


### PR DESCRIPTION
I attempted to start the "next steps" documentation so that users have a set of directions to follow to get all of the integrations up and running. This PR also integrates versioner into the project so that both `project.__version__` and `project. __git_revision__` work as expected.

I would not mind doing quick iterations on this as I may or may not get a chance to work more on these pieces for a bit. Please feel free to pull in at will.