### PR TITLE
Badges, Dependencies, and Py27 (oh my)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Testing is accomplished with both [Appveyor](https://www.appveyor.com) (for Wind
 are completely free for open source projects and allow you to automatically verify that your project works under a 
 variety of OS's and
 Python versions. To begin please register with both Appveyor and Travis-CI and turn on the git hooks under the project 
-tabs.
+tabs. You will also want to correct the badges which appear on the output README file to point to the correct links
 
 ### Documentation 
 Make a [ReadTheDocs](https://readthedocs.org) account and turn on the git hook...

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ remove deployment platforms, or test with a different suite.
 
 ## Requirements
 
-* Python 2.7, 3.5, or 3.6
+* Python 3.5, or 3.6
 * [Cookiecutter](http://cookiecutter.readthedocs.io/en/latest/installation.html)
 * [Git](https://git-scm.com/)
 
@@ -48,7 +48,13 @@ For development work it is often recommended to do a "local" python install via 
 new project into your Python site-packages folder so that it can be found in any directory on your computer.
 
 ### Setting up with GitHub
-...
+Upon creation, this project will initialize the output as a `git` repository compatible with 
+[Versioneer](https://github.com/warner/python-versioneer). However, this does not automatically register the 
+repository with GitHub. To do this, follow the instructions for 
+[Adding an existing project to GitHub using the command line](https://help.github.com/articles/adding-an-existing-project-to-github-using-the-command-line/). 
+Follow the first step to create the repository on GitHub, but ignore the warnings about the README, license, and 
+`.gitignore` files as this repo creates them. From there, you can skip to after the "first commit" instructions and 
+proceed from there.
 
 ### Testing
 The Python testing framework was chosen to be [pytest](https://pytest.org) for this project. Other testing frameworks are available;
@@ -63,12 +69,24 @@ contained within the `project/tests/` folder.
 Tests can be run with the `py.test -v` command. There are a number of additional command line arguments to [explore](https://docs.pytest.org/en/latest/usage.html).
 
 ### Continuous Integration
-Testing is accomplished with both [Appveyor](https://www.appveyor.com) (for Windows testing) and [Travis-CI](https://travis-ci.org) (for Linux testing). These frameworks are chosen as they
-are completely free for open source projects and allow you to automatically verify that your project works under a variety of OS's and
-Python versions. To begin please register with both Appveyor and Travis-CI and turn on the git hooks under the project tabs.
+Testing is accomplished with both [Appveyor](https://www.appveyor.com) (for Windows testing) and 
+[Travis-CI](https://travis-ci.org) (for Linux testing). These frameworks are chosen as they
+are completely free for open source projects and allow you to automatically verify that your project works under a 
+variety of OS's and
+Python versions. To begin please register with both Appveyor and Travis-CI and turn on the git hooks under the project 
+tabs.
 
 ### Documentation 
 Make a [ReadTheDocs](https://readthedocs.org) account and turn on the git hook...
+
+## Why is Python 2.X not on the supported versions?
+New projects generally should not be built with Python 2.7 support in mind, see the 
+[Python 3 Statement](https://python3statement.org/). Although the final Python 2.7 release will be 
+[supported through 2020](http://legacy.python.org/dev/peps/pep-0373/) and is the default on many legacy systems, Python 
+3 has been released for almost a decade and projects long term usage should not be shacked by legacy methods that will 
+have to be replaced in very short order as Python 2 support is retired.
+
+
 
 
 ## Output Skeleton
@@ -80,10 +98,10 @@ upon setup.
 .
 ├── LICENSE                         <- License file
 ├── README.md                       <- Description of project which GitHub will render
-├── appveyor.yml                    <- AppVeyor config file for Windows testing
+├── appveyor.yml                    <- AppVeyor config file for Windows testing (if chosen)
 ├── {{repo_name}}
 │   ├── __init__.py                 <- Basic Python Package import file
-│   ├── {{first_module_name}}.py   <- Starting packge module
+│   ├── {{first_module_name}}.py    <- Starting packge module
 │   ├── data                        <- Sample additional data (non-code) which can be packaged
 │   │   ├── README.md
 │   │   └── look_and_say.dat
@@ -93,7 +111,7 @@ upon setup.
 │   └── _version.py                 <- Automatic version control with Versioneer
 ├── devtools                        <- Deployment, packaging, and CI helpers directory 
 │   ├── README.md
-│   ├── appveyor
+│   ├── appveyor                    <- Appveyor config folder (if Windows testing chosen)
 │   ├── conda-recipe                <- Conda build and deployment skeleton
 │   │   ├── bld.bat
 │   │   ├── build.sh

--- a/README.md
+++ b/README.md
@@ -111,7 +111,6 @@ upon setup.
 │   └── _version.py                 <- Automatic version control with Versioneer
 ├── devtools                        <- Deployment, packaging, and CI helpers directory 
 │   ├── README.md
-│   ├── appveyor                    <- Appveyor config folder (if Windows testing chosen)
 │   ├── conda-recipe                <- Conda build and deployment skeleton
 │   │   ├── bld.bat
 │   │   ├── build.sh

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -6,7 +6,7 @@
     "description": "A short description of the project.",
     "open_source_license": ["MIT", "BSD-3-Clause", "LGPLv3", "Not Open Source"],
     "dependency_source": [
-        "Prefer conda-forge over default the anaconda channel, pip fallback",
+        "Prefer conda-forge over the default anaconda channel with pip fallback",
         "Prefer default anaconda channel with pip fallback",
         "Dependencies from pip only (no conda)"],
     "Include_Windows_continuous_integration": ["y","n"]

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -9,5 +9,5 @@
         "Prefer conda-forge over default the anaconda channel, pip fallback",
         "Prefer default anaconda channel with pip fallback",
         "Dependencies from pip only (no conda)"],
-    "Include Windows Continuous Integration and Tests": ["y","n"]
+    "Include_Windows_continuous_integration": ["y","n"]
 }

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -5,5 +5,9 @@
     "author_name": "Your name (or your organization/company/team)",
     "description": "A short description of the project.",
     "open_source_license": ["MIT", "BSD-3-Clause", "LGPLv3", "Not Open Source"],
-    "dependency_source": ["conda-forge", "conda", "pip"]
+    "dependency_source": [
+        "Prefer conda-forge over default the anaconda channel, pip fallback",
+        "Prefer default anaconda channel with pip fallback",
+        "Dependencies from pip only (no conda)"],
+    "Include Windows Continuous Integration and Tests": ["y","n"]
 }

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -5,6 +5,7 @@ These scripts are executed from the output folder.
 If any error is raised, the cookie cutter creation fails and crashes
 """
 
+import os
 import subprocess as sp
 
 repo_name = '{{ cookiecutter.repo_name }}'
@@ -34,10 +35,18 @@ def git_init_and_tag():
     # Initialize git
     invoke_shell("git init")
     # Add files
-    invoke_shell("git add *")
+    invoke_shell("git add .")
     invoke_shell("git commit -m \"Initial commit after Comp. Chem. Cookiecutter creation\"")
     # Set the 0.0.0 tag
     invoke_shell("git tag 0.0.0")
 
 
+def remove_windows_ci():
+    include_windows = '{{ cookiecutter.Include_Windows_continuous_integration }}'
+    if include_windows == "n":
+        # Remove with appveyor to be a safe delete
+        os.remove("appveyor.yml")
+
+
+remove_windows_ci()
 git_init_and_tag()

--- a/{{cookiecutter.repo_name}}/.travis.yml
+++ b/{{cookiecutter.repo_name}}/.travis.yml
@@ -33,11 +33,11 @@ before_install:
 
 install:
 # Install the package locally
-{% if (cookiecutter.dependency_source == 'Prefer conda-forge over default the anaconda channel, pip fallback' or cookiecutter.dependency_source == 'Prefer default anaconda channel with pip fallback') %}
+{% if (cookiecutter.dependency_source == 'Prefer conda-forge over the default anaconda channel with pip fallback' or cookiecutter.dependency_source == 'Prefer default anaconda channel with pip fallback') %}
     # Create test environment for package
   - conda create --yes -n test python=$PYTHON_VER pip pytest pytest-cov
   - source activate test
-    {% if cookiecutter.dependency_source == "Prefer conda-forge over default the anaconda channel, pip fallback" %}
+    {% if cookiecutter.dependency_source == "Prefer conda-forge over the default anaconda channel with pip fallback" %}
   - conda install --yes codecov  # Only available in conda-forge channel or pip
     {% else %}
   - pip install codecov  # Only available in conda-forge channel or pip

--- a/{{cookiecutter.repo_name}}/.travis.yml
+++ b/{{cookiecutter.repo_name}}/.travis.yml
@@ -33,11 +33,11 @@ before_install:
 
 install:
 # Install the package locally
-{% if (cookiecutter.dependency_source == 'conda-forge' or cookiecutter.dependency_source == 'conda') %}
+{% if (cookiecutter.dependency_source == 'Prefer conda-forge over default the anaconda channel, pip fallback' or cookiecutter.dependency_source == 'Prefer default anaconda channel with pip fallback') %}
     # Create test environment for package
   - conda create --yes -n test python=$PYTHON_VER pip pytest pytest-cov
   - source activate test
-    {% if cookiecutter.dependency_source == "conda-forge" %}
+    {% if cookiecutter.dependency_source == "Prefer conda-forge over default the anaconda channel, pip fallback" %}
   - conda install --yes codecov  # Only available in conda-forge channel or pip
     {% else %}
   - pip install codecov  # Only available in conda-forge channel or pip
@@ -45,7 +45,7 @@ install:
     # Build and install package
   - conda build --python=$PYTHON_VER devtools/conda-recipe
   - conda install --yes --use-local {{cookiecutter.repo_name}}
-{% elif cookiecutter.dependency_source == 'pip' %}
+{% elif cookiecutter.dependency_source == 'Dependencies from pip only (no conda)' %}
   - pip install -e .
 {% endif %}
 

--- a/{{cookiecutter.repo_name}}/README.md
+++ b/{{cookiecutter.repo_name}}/README.md
@@ -1,5 +1,11 @@
 {{cookiecutter.project_name}}
 ==============================
+[comment]: <> (Badges)
+[![Travis Build Status](https://travis-ci.org/REPLACE_WITH_OWNER_ACCOUNT/{{cookiecutter.project_name}}.png)](https://travis-ci.org/REPLACE_WITH_OWNER_ACCOUNT/{{cookiecutter.project_name}})
+{% if cookiecutter.Include_Windows_continuous_integration == "y" -%}
+[![AppVeyor Build status](https://ci.appveyor.com/api/projects/status/REPLACE_WITH_APPVEYOR_LINK/branch/master?svg=true)](https://ci.appveyor.com/project/REPLACE_WITH_OWNER_ACCOUNT/{{cookiecutter.project_name}}/branch/master)
+{% endif -%}
+[![codecov](https://codecov.io/gh/REPLACE_WITH_OWNER_ACCOUNT/{{cookiecutter.project_name}}/branch/master/graph/badge.svg)](https://codecov.io/gh/REPLACE_WITH_OWNER_ACCOUNT/{{cookiecutter.project_name}}/branch/master)
 
 {{cookiecutter.description}}
 

--- a/{{cookiecutter.repo_name}}/appveyor.yml
+++ b/{{cookiecutter.repo_name}}/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
 
   matrix:
-  {% if (cookiecutter.dependency_source == 'Prefer conda-forge over default the anaconda channel, pip fallback' or cookiecutter.dependency_source == 'Prefer default anaconda channel with pip fallback') %}
+  {% if (cookiecutter.dependency_source == 'Prefer conda-forge over the default anaconda channel with pip fallback' or cookiecutter.dependency_source == 'Prefer default anaconda channel with pip fallback') %}
     - PYTHON: "C:\\Miniconda-x64"
       PYTHON_VERSION: "2.7"
       PYTHON_ARCH: "64"
@@ -29,8 +29,8 @@ environment:
 
 install:
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
-  {% if (cookiecutter.dependency_source == 'Prefer conda-forge over default the anaconda channel, pip fallback' or cookiecutter.dependency_source == 'Prefer default anaconda channel with pip fallback') %}
-  {% if cookiecutter.dependency_source == 'Prefer conda-forge over default the anaconda channel, pip fallback' %}
+  {% if (cookiecutter.dependency_source == 'Prefer conda-forge over the default anaconda channel with pip fallback' or cookiecutter.dependency_source == 'Prefer default anaconda channel with pip fallback') %}
+  {% if cookiecutter.dependency_source == 'Prefer conda-forge over the default anaconda channel with pip fallback' %}
   # Add conda-forge channel
   - conda config --add channels conda-forge
   {% endif %}
@@ -41,7 +41,7 @@ install:
   - conda create --yes -n test python=%PYTHON_VERSION% pip pytest pytest-cov
   # Switch to test environment
   - activate test
-    {% if cookiecutter.dependency_source == 'Prefer conda-forge over default the anaconda channel, pip fallback' %}
+    {% if cookiecutter.dependency_source == 'Prefer conda-forge over the default anaconda channel with pip fallback' %}
   - conda install --yes codecov
     {% else %}
   - pip install codecov  # Only available on Pip and Conda-forge

--- a/{{cookiecutter.repo_name}}/appveyor.yml
+++ b/{{cookiecutter.repo_name}}/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
 
   matrix:
-  {% if (cookiecutter.dependency_source == 'conda-forge' or cookiecutter.dependency_source == 'conda') %}
+  {% if (cookiecutter.dependency_source == 'Prefer conda-forge over default the anaconda channel, pip fallback' or cookiecutter.dependency_source == 'Prefer default anaconda channel with pip fallback') %}
     - PYTHON: "C:\\Miniconda-x64"
       PYTHON_VERSION: "2.7"
       PYTHON_ARCH: "64"
@@ -13,7 +13,7 @@ environment:
     - PYTHON: "C:\\Miniconda36-x64"
       PYTHON_VERSION: "3.6"
       PYTHON_ARCH: "64"
-  {% elif cookiecutter.dependency_source == 'pip' %}
+  {% elif cookiecutter.dependency_source == 'Dependencies from pip only (no conda)' %}
     - PYTHON: "C:\\Python27-x64"
       PYTHON_VERSION: "2.7"
       PYTHON_ARCH: "64"
@@ -29,8 +29,8 @@ environment:
 
 install:
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
-  {% if (cookiecutter.dependency_source == 'conda-forge' or cookiecutter.dependency_source == 'conda') %}
-  {% if cookiecutter.dependency_source == 'conda-forge' %}
+  {% if (cookiecutter.dependency_source == 'Prefer conda-forge over default the anaconda channel, pip fallback' or cookiecutter.dependency_source == 'Prefer default anaconda channel with pip fallback') %}
+  {% if cookiecutter.dependency_source == 'Prefer conda-forge over default the anaconda channel, pip fallback' %}
   # Add conda-forge channel
   - conda config --add channels conda-forge
   {% endif %}
@@ -41,14 +41,14 @@ install:
   - conda create --yes -n test python=%PYTHON_VERSION% pip pytest pytest-cov
   # Switch to test environment
   - activate test
-    {% if cookiecutter.dependency_source == 'conda-forge' %}
+    {% if cookiecutter.dependency_source == 'Prefer conda-forge over default the anaconda channel, pip fallback' %}
   - conda install --yes codecov
     {% else %}
   - pip install codecov  # Only available on Pip and Conda-forge
     {% endif %}
   - conda build --quiet --python=%PYTHON_VERSION% devtools\\conda-recipe
   - conda install --yes --use-local {{cookiecutter.repo_name}}
-  {% elif cookiecutter.dependency_source == 'pip' %}
+  {% elif cookiecutter.dependency_source == 'Dependencies from pip only (no conda)' %}
   - pip install --upgrade pip setuptools
   - pip install pytest pytest-cov codecov
   - pip install -e .

--- a/{{cookiecutter.repo_name}}/devtools/travis-ci/install.sh
+++ b/{{cookiecutter.repo_name}}/devtools/travis-ci/install.sh
@@ -1,7 +1,7 @@
 # Temporarily change directory to $HOME to install software
 pushd .
 cd $HOME
-{% if (cookiecutter.dependency_source == 'Prefer conda-forge over default the anaconda channel, pip fallback' or cookiecutter.dependency_source == 'Prefer default anaconda channel with pip fallback') %}
+{% if (cookiecutter.dependency_source == 'Prefer conda-forge over the default anaconda channel with pip fallback' or cookiecutter.dependency_source == 'Prefer default anaconda channel with pip fallback') %}
 # Install Miniconda
 if [ "$TRAVIS_OS_NAME" == "osx" ]; then
     # Make OSX md5 mimic md5sum from linux, alias does not work
@@ -25,7 +25,7 @@ bash $MINICONDA -b -p $MINICONDA_HOME
 # Configure miniconda
 export PIP_ARGS="-U"
 export PATH=$MINICONDA_HOME/bin:$PATH
-    {% if cookiecutter.dependency_source == "Prefer conda-forge over default the anaconda channel, pip fallback" %}
+    {% if cookiecutter.dependency_source == "Prefer conda-forge over the default anaconda channel with pip fallback" %}
 conda config --add channels conda-forge
     {% endif %}
 conda install --yes conda conda-build jinja2 anaconda-client

--- a/{{cookiecutter.repo_name}}/devtools/travis-ci/install.sh
+++ b/{{cookiecutter.repo_name}}/devtools/travis-ci/install.sh
@@ -1,7 +1,7 @@
 # Temporarily change directory to $HOME to install software
 pushd .
 cd $HOME
-{% if (cookiecutter.dependency_source == 'conda-forge' or cookiecutter.dependency_source == 'conda') %}
+{% if (cookiecutter.dependency_source == 'Prefer conda-forge over default the anaconda channel, pip fallback' or cookiecutter.dependency_source == 'Prefer default anaconda channel with pip fallback') %}
 # Install Miniconda
 if [ "$TRAVIS_OS_NAME" == "osx" ]; then
     # Make OSX md5 mimic md5sum from linux, alias does not work
@@ -25,12 +25,12 @@ bash $MINICONDA -b -p $MINICONDA_HOME
 # Configure miniconda
 export PIP_ARGS="-U"
 export PATH=$MINICONDA_HOME/bin:$PATH
-    {% if cookiecutter.dependency_source == "conda-forge" %}
+    {% if cookiecutter.dependency_source == "Prefer conda-forge over default the anaconda channel, pip fallback" %}
 conda config --add channels conda-forge
     {% endif %}
 conda install --yes conda conda-build jinja2 anaconda-client
 conda update --quiet --yes --all
-{% elif cookiecutter.dependency_source == 'pip' %}
+{% elif cookiecutter.dependency_source == 'Dependencies from pip only (no conda)' %}
 if [ "$TRAVIS_OS_NAME" == "osx" ]; then
     brew upgrade pyenv
     # Pyenv requires minor revision, get the latest

--- a/{{cookiecutter.repo_name}}/docs/README.md
+++ b/{{cookiecutter.repo_name}}/docs/README.md
@@ -3,11 +3,11 @@
 The docs for this project are built with [Sphinx](http://www.sphinx-doc.org/en/master/).
 To compile the docs, first ensure that Sphinx and the ReadTheDocs theme are installed.
 
-{% if (cookiecutter.dependency_source == 'conda-forge' or cookiecutter.dependency_source == 'conda') %}
+{% if (cookiecutter.dependency_source == 'Prefer conda-forge over default the anaconda channel, pip fallback' or cookiecutter.dependency_source == 'Prefer default anaconda channel with pip fallback') %}
 ```bash
 conda install sphinx sphinx_rtd_theme 
 ```
-{% elif cookiecutter.dependency_source == 'pip' %}
+{% elif cookiecutter.dependency_source == 'Dependencies from pip only (no conda)' %}
 ```bash
 pip install sphinx sphinx_rtd_theme
 ```

--- a/{{cookiecutter.repo_name}}/docs/README.md
+++ b/{{cookiecutter.repo_name}}/docs/README.md
@@ -3,7 +3,7 @@
 The docs for this project are built with [Sphinx](http://www.sphinx-doc.org/en/master/).
 To compile the docs, first ensure that Sphinx and the ReadTheDocs theme are installed.
 
-{% if (cookiecutter.dependency_source == 'Prefer conda-forge over default the anaconda channel, pip fallback' or cookiecutter.dependency_source == 'Prefer default anaconda channel with pip fallback') %}
+{% if (cookiecutter.dependency_source == 'Prefer conda-forge over the default anaconda channel with pip fallback' or cookiecutter.dependency_source == 'Prefer default anaconda channel with pip fallback') %}
 ```bash
 conda install sphinx sphinx_rtd_theme 
 ```


### PR DESCRIPTION
Second wave of cleanups from initial feedback:

* Drops support for Python 2.7 with links and reasons on primary README (Fixes #18)
* Makes the Dependency selection much more friendly (Fixes #17)
  ```
  Select dependency_source:
  1 - Prefer conda-forge over the default anaconda channel with pip fallback
  2 - Prefer default anaconda channel with pip fallback
  3 - Dependencies from pip only (no conda)
  Choose from 1, 2, 3 [1]:
  ```
* Fills in more instructions on what to do next (Progress on #9)
* Adds Windows support toggle and deletes files if not chosen (Based on suggestion in #19)
* Adds badges, more badges, MORE BADGES okay stop badges (Fixes #19)
* Fixed a bug where the hidden files (`.*`) where not added by `git` 

Feedback welcome!