### PR TITLE
Add readmes for the empty doc directories

### DIFF
--- a/{{cookiecutter.repo_name}}/docs/_static/README.md
+++ b/{{cookiecutter.repo_name}}/docs/_static/README.md
@@ -1,0 +1,16 @@
+# Static Doc Directory
+
+Add any paths that contain custom static files (such as style sheets) here,
+relative to the `conf.py` file's directory. 
+They are copied after the builtin static files,
+so a file named "default.css" will overwrite the builtin "default.css".
+
+The path to this folder is set in the Sphinx `conf.py` file in the line: 
+```python
+templates_path = ['_static']
+```
+
+## Examples of file to add to this directory
+* Custom Cascading Style Sheets
+* Custom JavaScript code
+* Static logo images

--- a/{{cookiecutter.repo_name}}/docs/_templates/README.md
+++ b/{{cookiecutter.repo_name}}/docs/_templates/README.md
@@ -1,0 +1,14 @@
+# Templates Doc Directory
+
+Add any paths that contain templates here, relative to  
+the `conf.py` file's directory.
+They are copied after the builtin template files,
+so a file named "page.html" will overwrite the builtin "page.html".
+
+The path to this folder is set in the Sphinx `conf.py` file in the line: 
+```python
+html_static_path = ['_templates']
+```
+
+## Examples of file to add to this directory
+* HTML extensions of stock pages like `page.html` or `layout.html`


### PR DESCRIPTION
Since Git cannot add empty directories, this PR adds README's into
empty directories which are still helpful for defining doc
structure. 

It also provides some simple cases of what should
go in the folder should the user(s) decide to take advantage
of them.