### PR TITLE
Installed testing function

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/__init__.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/__init__.py
@@ -3,10 +3,6 @@
 {{cookiecutter.description}}
 """
 
-# Make Python 2 and 3 imports work the same
-# Safe to remove with Python 3-only code
-from __future__ import absolute_import
-
 # Add imports here
 from .{{cookiecutter.first_module_name}} import *
 

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/__init__.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/__init__.py
@@ -10,6 +10,9 @@ from __future__ import absolute_import
 # Add imports here
 from .{{cookiecutter.first_module_name}} import *
 
+# Move any desired extra features up
+from .extras import test
+
 # Handle versioneer
 from ._version import get_versions
 versions = get_versions()

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/extras.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/extras.py
@@ -1,0 +1,18 @@
+"""
+Additional functionality not directly related to {{cookiecutter.project_name}}.
+"""
+
+import os
+
+def test():
+    """
+    Runs a smoke test suite through pytest after the module is installed.
+    """
+
+    try:
+        import pytest
+    except ImportError:
+        raise RuntimeError('Testing module `pytest` is not installed. Run `conda install pytest`')
+
+    abs_test_dir = os.path.sep.join([os.path.abspath(os.path.dirname(__file__)), "tests"])
+    pytest.main(['-rws', '-v', '--capture=sys', abs_test_dir])


### PR DESCRIPTION
Adds a small function (credit @loriab) which allows pytest to be run after a module has been installed as `module.test()`. This makes it a bit easier to run the tests instead of something like: 

```
py.test -v `import module, os; os.path.abspath(os.path.dirname(module.__file__))`
```