### PR TITLE
add pytest_cache to gitignore

### DIFF
--- a/{{cookiecutter.repo_name}}/.gitignore
+++ b/{{cookiecutter.repo_name}}/.gitignore
@@ -41,6 +41,7 @@ htmlcov/
 .coverage
 .coverage.*
 .cache
+.pytest_cache
 nosetests.xml
 coverage.xml
 *.cover


### PR DESCRIPTION
Pytest has renamed the `.cache` dir to `.pytest_cache` as of [this PR](https://github.com/pytest-dev/pytest/pull/3150). 

This adds the new directory to the .gitignore for anyone using a newer (>=3.4.0) version of pytest. The old `.cache` is left in for those using anything older.