### PR TITLE
Changes conda to always_yes

### DIFF
--- a/{{cookiecutter.repo_name}}/.travis.yml
+++ b/{{cookiecutter.repo_name}}/.travis.yml
@@ -37,7 +37,7 @@ install:
   - pip install -e .
 {% else %}
     # Create test environment for package
-  - conda create --yes -n test python=$PYTHON_VER pip pytest pytest-cov
+  - conda create -n test python=$PYTHON_VER pip pytest pytest-cov
   - source activate test
 
     # Install pip only modules
@@ -45,7 +45,7 @@ install:
 
     # Build and install package
   - conda build --python=$PYTHON_VER devtools/conda-recipe
-  - conda install --yes --use-local {{cookiecutter.repo_name}}
+  - conda install --use-local {{cookiecutter.repo_name}}
 {% endif %}
 
 script:

--- a/{{cookiecutter.repo_name}}/appveyor.yml
+++ b/{{cookiecutter.repo_name}}/appveyor.yml
@@ -26,12 +26,16 @@ install:
     # Add conda-forge channel
   - conda config --add channels conda-forge
   {% endif %}
+
+    # Always run commands without asking
+  - conda config --set always_yes yes
+
     # Try to update conda first to avoid odd dependency clashes
-  - conda update --yes --all
-  - conda install --yes conda-build
+  - conda update --all
+  - conda install conda-build
 
     # Create test environment for package
-  - conda create --yes -n test python=%PYTHON_VERSION% pip pytest pytest-cov
+  - conda create -n test python=%PYTHON_VERSION% pip pytest pytest-cov
   - activate test
     
     # Install any pip only modules
@@ -39,7 +43,7 @@ install:
 
     # Build and install package
   - conda build --quiet --python=%PYTHON_VERSION% devtools\\conda-recipe
-  - conda install --yes --use-local {{cookiecutter.repo_name}}
+  - conda install --use-local {{cookiecutter.repo_name}}
   {% elif cookiecutter.dependency_source == 'Dependencies from pip only (no conda)' %}
     # Install the package locally
   - pip install --upgrade pip setuptools

--- a/{{cookiecutter.repo_name}}/devtools/travis-ci/before_install.sh
+++ b/{{cookiecutter.repo_name}}/devtools/travis-ci/before_install.sh
@@ -28,8 +28,9 @@ export PATH=$MINICONDA_HOME/bin:$PATH
     {% if cookiecutter.dependency_source == "Prefer conda-forge over the default anaconda channel with pip fallback" %}
 conda config --add channels conda-forge
     {% endif %}
-conda install --yes conda conda-build jinja2 anaconda-client
-conda update --quiet --yes --all
+conda config --set always_yes yes
+conda install conda conda-build jinja2 anaconda-client
+conda update --quiet --all
 {% elif cookiecutter.dependency_source == 'Dependencies from pip only (no conda)' %}
 if [ "$TRAVIS_OS_NAME" == "osx" ]; then
     brew upgrade pyenv


### PR DESCRIPTION
Sets Conda always_yes so that builds do not hang if a user/developer forgets to add --yes to every command. We could potentially purge all --yes from other parts of the code as well.

Had some odd head state due to the way the last commit/PR was made. It was easier to nuke and remake rather than fix.