### PR TITLE
Add travis tests for cookiecutter install with defaults

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,5 @@ install:
     - pip install cookiecutter
 
 script:
-    - cookiecutter gh:choderalab/cookiecutter-compchem
+    - cookiecutter . --no-input
     - cd project_name; py.test -vv; cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+sudo: false
+language: python
+
+matrix:
+    include:
+      - python: 2.7
+      - python: 3.5
+      - python: 3.6
+
+install:
+    - pip install cookiecutter
+
+script:
+    - cookiecutter gh:choderalab/cookiecutter-compchem
+    - cd project_name; py.test -vv; cd ..


### PR DESCRIPTION
This PR adds a very simple automated travis test to make sure cookiecutter creation from the current template proceeds without errors.