### PR TITLE
Modifies CB script line

### DIFF
--- a/{{cookiecutter.repo_name}}/devtools/conda-recipe/bld.bat
+++ b/{{cookiecutter.repo_name}}/devtools/conda-recipe/bld.bat
@@ -1,2 +1,2 @@
-"%PYTHON%" setup.py install
+"%PYTHON%" setup.py install --single-version-externally-managed --record=record.txt
 if errorlevel 1 exit 1

--- a/{{cookiecutter.repo_name}}/devtools/conda-recipe/build.sh
+++ b/{{cookiecutter.repo_name}}/devtools/conda-recipe/build.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # Build the python package
-$PYTHON setup.py install
+$PYTHON setup.py install --single-version-externally-managed --record=record.txt

--- a/{{cookiecutter.repo_name}}/devtools/conda-recipe/meta.yaml
+++ b/{{cookiecutter.repo_name}}/devtools/conda-recipe/meta.yaml
@@ -9,7 +9,7 @@ build:
   number: 0
 
 requirements:
-  build:
+  host:
     - python
     - setuptools
 


### PR DESCRIPTION
Ensures that `setup.py` and conda `meta.yaml` does not run into build conflicts as conda uses staged build/run dependencies.

Also, `build` -> `host` as per cb3 recommendations.