### PR TITLE
Update many things, mostly travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -97,7 +97,7 @@ matrix:
 
 before_install:
     # Make sure pip is around
-  - if [[ "$TRAVIS_OS_NAME" == "osx" && ! $(command -v pip) ]]; then echo $(which pip2); echo $(which python); mkdir -p $HOME/bin && ln -s $(which pip2) $HOME/bin/pip; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" && ! $(command -v pip) ]]; then ls -l $(which pip2); ls -l $(which python); mkdir -p $HOME/bin && ln -s $(which pip2) $HOME/bin/pip; fi
     # Make sure pip is around (works on > 3.4 which the cookiecutter is)
   # - sudo python -m ensurepip
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+language: python
+
 matrix:
   include:
     - env:
@@ -96,6 +98,9 @@ matrix:
         - PYTHON_VER=3.5
 
 before_install:
+    # Configure the fact that travis is missing some things
+  - if [[ $TRAVIS_OS_NAME == 'osx' && $(command -v pip) ]]; then ln -s pip3 pip; fi
+
     # Install a few requirements
   - pip install pyyaml cookiecutter
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -98,7 +98,7 @@ matrix:
 before_install:
     # Make sure pip is around
   # - if [[ "$TRAVIS_OS_NAME" == "osx" && ! $(command -v pip) ]]; then ls -l $(which pip2); ls -l $(which python); mkdir -p $HOME/bin && ln -s $(which pip2) $HOME/bin/pip; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" && ! $(command -v pip) ]]; then easy_install pip fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" && ! $(command -v pip) ]]; then easy_install pip; fi
     # Make sure pip is around (works on > 3.4 which the cookiecutter is)
   # - sudo python -m ensurepip
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,78 +22,78 @@ matrix:
         - LICENSE=1
         - DEPEND_SOURCE=1
         - PYTHON_VER=3.6
-    - os: osx
-      language: generic
-      env:
-        - LICENSE=1
-        - DEPEND_SOURCE=2
-        - PYTHON_VER=3.6
-    - os: osx
-      language: generic
-      env:
-        - LICENSE=2
-        - DEPEND_SOURCE=3
-        - PYTHON_VER=3.6
-    - os: osx
-      language: generic
-      env:
-        - LICENSE=1
-        - DEPEND_SOURCE=1
-        - PYTHON_VER=3.5
-    - os: osx
-      language: generic
-      env:
-        - LICENSE=1
-        - DEPEND_SOURCE=2
-        - PYTHON_VER=3.5
-    - os: osx
-      language: generic
-      env:
-        - LICENSE=2
-        - DEPEND_SOURCE=3
-        - PYTHON_VER=3.5
-
-    - os: linux
-      python: 3.6
-      env:
-        - LICENSE=1
-        - DEPEND_SOURCE=1
-        - PYTHON_VER=3.6
-
-    - os: linux
-      python: 3.6
-      env:
-        - LICENSE=1
-        - DEPEND_SOURCE=2
-        - PYTHON_VER=3.6
-
-    - os: linux
-      python: 3.6
-      env:
-        - LICENSE=2
-        - DEPEND_SOURCE=3
-        - PYTHON_VER=3.6
-
-    - os: linux
-      python: 3.5
-      env:
-        - LICENSE=1
-        - DEPEND_SOURCE=1
-        - PYTHON_VER=3.5
-
-    - os: linux
-      python: 3.5
-      env:
-        - LICENSE=1
-        - DEPEND_SOURCE=2
-        - PYTHON_VER=3.5
-
-    - os: linux
-      python: 3.5
-      env:
-        - LICENSE=2
-        - DEPEND_SOURCE=3
-        - PYTHON_VER=3.5
+#    - os: osx
+#      language: generic
+#      env:
+#        - LICENSE=1
+#        - DEPEND_SOURCE=2
+#        - PYTHON_VER=3.6
+#    - os: osx
+#      language: generic
+#      env:
+#        - LICENSE=2
+#        - DEPEND_SOURCE=3
+#        - PYTHON_VER=3.6
+#    - os: osx
+#      language: generic
+#      env:
+#        - LICENSE=1
+#        - DEPEND_SOURCE=1
+#        - PYTHON_VER=3.5
+#    - os: osx
+#      language: generic
+#      env:
+#        - LICENSE=1
+#        - DEPEND_SOURCE=2
+#        - PYTHON_VER=3.5
+#    - os: osx
+#      language: generic
+#      env:
+#        - LICENSE=2
+#        - DEPEND_SOURCE=3
+#        - PYTHON_VER=3.5
+#
+#    - os: linux
+#      python: 3.6
+#      env:
+#        - LICENSE=1
+#        - DEPEND_SOURCE=1
+#        - PYTHON_VER=3.6
+#
+#    - os: linux
+#      python: 3.6
+#      env:
+#        - LICENSE=1
+#        - DEPEND_SOURCE=2
+#        - PYTHON_VER=3.6
+#
+#    - os: linux
+#      python: 3.6
+#      env:
+#        - LICENSE=2
+#        - DEPEND_SOURCE=3
+#        - PYTHON_VER=3.6
+#
+#    - os: linux
+#      python: 3.5
+#      env:
+#        - LICENSE=1
+#        - DEPEND_SOURCE=1
+#        - PYTHON_VER=3.5
+#
+#    - os: linux
+#      python: 3.5
+#      env:
+#        - LICENSE=1
+#        - DEPEND_SOURCE=2
+#        - PYTHON_VER=3.5
+#
+#    - os: linux
+#      python: 3.5
+#      env:
+#        - LICENSE=2
+#        - DEPEND_SOURCE=3
+#        - PYTHON_VER=3.5
 
 before_install:
     # Make sure pip is around
@@ -102,7 +102,7 @@ before_install:
   # - sudo python -m ensurepip
 
     # Install a few requirements
-  - pip install pyyaml cookiecutter
+  - sudo pip install pyyaml cookiecutter
 
     # Build out the cookiecutter from settings
   - python tests/setup_cookiecutter.py default_project $LICENSE $DEPEND_SOURCE

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,21 +54,18 @@ matrix:
         - PYTHON_VER=3.5
 
     - os: linux
-      language: python
       python: 3.6
       env:
         - LICENSE=1
         - DEPEND_SOURCE=1
         - PYTHON_VER=3.6
     - os: linux
-      language: python
       python: 3.6
       env:
         - LICENSE=1
         - DEPEND_SOURCE=2
         - PYTHON_VER=3.6
     - os: linux
-      language: python
       python: 3.6
       env:
         - LICENSE=2
@@ -76,21 +73,18 @@ matrix:
         - PYTHON_VER=3.6
 
     - os: linux
-      language: python
       python: 3.5
       env:
         - LICENSE=1
         - DEPEND_SOURCE=1
         - PYTHON_VER=3.5
     - os: linux
-      language: python
       python: 3.5
       env:
         - LICENSE=1
         - DEPEND_SOURCE=2
         - PYTHON_VER=3.5
     - os: linux
-      language: python
       python: 3.5
       env:
         - LICENSE=2
@@ -99,8 +93,8 @@ matrix:
 
 before_install:
     # Make sure pip is around (works on > 3.4 which the cookiecutter is)
-  # - if [[ $TRAVIS_OS_NAME == 'osx' && ! $(command -v pip) ]]; then ln -s pip3 pip; fi
-  - sudo python -m ensurepip
+  - if [[ $TRAVIS_OS_NAME == 'osx' && ! $(command -v pip) ]]; then mkdir -p $HOME/bin && ln -s $(which pip3) $HOME/bin/pip; fi
+  # - sudo python -m ensurepip
 
     # Install a few requirements
   - pip install pyyaml cookiecutter

--- a/.travis.yml
+++ b/.travis.yml
@@ -97,13 +97,13 @@ matrix:
 
 before_install:
     # Make sure pip is around
-  # - if [[ "$TRAVIS_OS_NAME" == "osx" && ! $(command -v pip) ]]; then ls -l $(which pip2); ls -l $(which python); mkdir -p $HOME/bin && ln -s $(which pip2) $HOME/bin/pip; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" && ! $(command -v pip) ]]; then sudo easy_install pip; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" && ! $(command -v pip) ]]; then mkdir -p $HOME/bin && ln -s $(which pip2) $HOME/bin/pip; fi
+  # - if [[ "$TRAVIS_OS_NAME" == "osx" && ! $(command -v pip) ]]; then easy_install pip --user; fi
     # Make sure pip is around (works on > 3.4 which the cookiecutter is)
   # - sudo python -m ensurepip
 
     # Install a few requirements
-  - sudo pip install pyyaml cookiecutter
+  - pip install --user pyyaml cookiecutter
 
     # Build out the cookiecutter from settings
   - python tests/setup_cookiecutter.py default_project $LICENSE $DEPEND_SOURCE

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,3 @@
-language: python
-
-python:
-    - 3.6
-
 matrix:
   include:
     - env:
@@ -17,6 +12,88 @@ matrix:
        - LICENSE=2
        - DEPEND_SOURCE=3
        - PYTHON_VER=3.6
+
+    # Extra includes for OSX since python language is not available by default on OSX
+    - os: osx
+      language: generic
+      env:
+        - LICENSE=1
+        - DEPEND_SOURCE=1
+        - PYTHON_VER=3.6
+    - os: osx
+      language: generic
+      env:
+        - LICENSE=1
+        - DEPEND_SOURCE=2
+        - PYTHON_VER=3.6
+    - os: osx
+      language: generic
+      env:
+        - LICENSE=2
+        - DEPEND_SOURCE=3
+        - PYTHON_VER=3.6
+    - os: osx
+      language: generic
+      env:
+        - LICENSE=1
+        - DEPEND_SOURCE=1
+        - PYTHON_VER=3.5
+    - os: osx
+      language: generic
+      env:
+        - LICENSE=1
+        - DEPEND_SOURCE=2
+        - PYTHON_VER=3.5
+    - os: osx
+      language: generic
+      env:
+        - LICENSE=2
+        - DEPEND_SOURCE=3
+        - PYTHON_VER=3.5
+
+    - os: linux
+      language: python
+      python: 3.6
+      env:
+        - LICENSE=1
+        - DEPEND_SOURCE=1
+        - PYTHON_VER=3.6
+    - os: linux
+      language: python
+      python: 3.6
+      env:
+        - LICENSE=1
+        - DEPEND_SOURCE=2
+        - PYTHON_VER=3.6
+    - os: linux
+      language: python
+      python: 3.6
+      env:
+        - LICENSE=2
+        - DEPEND_SOURCE=3
+        - PYTHON_VER=3.6
+
+    - os: linux
+      language: python
+      python: 3.5
+      env:
+        - LICENSE=1
+        - DEPEND_SOURCE=1
+        - PYTHON_VER=3.5
+    - os: linux
+      language: python
+      python: 3.5
+      env:
+        - LICENSE=1
+        - DEPEND_SOURCE=2
+        - PYTHON_VER=3.5
+    - os: linux
+      language: python
+      python: 3.5
+      env:
+        - LICENSE=2
+        - DEPEND_SOURCE=3
+        - PYTHON_VER=3.5
 
 before_install:
     # Install a few requirements

--- a/.travis.yml
+++ b/.travis.yml
@@ -103,7 +103,7 @@ before_install:
   # - sudo python -m ensurepip
 
     # Install a few requirements
-  - pip install --user pyyaml cookiecutter
+  - pip install pyyaml cookiecutter
 
     # Build out the cookiecutter from settings
   - python tests/setup_cookiecutter.py default_project $LICENSE $DEPEND_SOURCE

--- a/.travis.yml
+++ b/.travis.yml
@@ -99,7 +99,7 @@ before_install:
     # Make sure pip is around
   # - if [[ "$TRAVIS_OS_NAME" == "osx" && ! $(command -v pip) ]]; then mkdir -p $HOME/bin && ln -s $(which pip2) $HOME/bin/pip; fi
   # - if [[ "$TRAVIS_OS_NAME" == "osx" && ! $(command -v pip) ]]; then easy_install pip --user; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" && ! $(command -v pip) ]]; then brew install python pip; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" && ! $(command -v pip) ]]; then bash cihelpers/osx_travis_py_helper.sh; fi
     # Make sure pip is around (works on > 3.4 which the cookiecutter is)
   # - sudo python -m ensurepip
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,82 +22,82 @@ matrix:
         - LICENSE=1
         - DEPEND_SOURCE=1
         - PYTHON_VER=3.6
-    - os: osx
-      language: generic
-      env:
-        - LICENSE=1
-        - DEPEND_SOURCE=2
-        - PYTHON_VER=3.6
-    - os: osx
-      language: generic
-      env:
-        - LICENSE=2
-        - DEPEND_SOURCE=3
-        - PYTHON_VER=3.6
-    - os: osx
-      language: generic
-      env:
-        - LICENSE=1
-        - DEPEND_SOURCE=1
-        - PYTHON_VER=3.5
-    - os: osx
-      language: generic
-      env:
-        - LICENSE=1
-        - DEPEND_SOURCE=2
-        - PYTHON_VER=3.5
-    - os: osx
-      language: generic
-      env:
-        - LICENSE=2
-        - DEPEND_SOURCE=3
-        - PYTHON_VER=3.5
-
-    - os: linux
-      python: 3.6
-      env:
-        - LICENSE=1
-        - DEPEND_SOURCE=1
-        - PYTHON_VER=3.6
-
-    - os: linux
-      python: 3.6
-      env:
-        - LICENSE=1
-        - DEPEND_SOURCE=2
-        - PYTHON_VER=3.6
-
-    - os: linux
-      python: 3.6
-      env:
-        - LICENSE=2
-        - DEPEND_SOURCE=3
-        - PYTHON_VER=3.6
-
-    - os: linux
-      python: 3.5
-      env:
-        - LICENSE=1
-        - DEPEND_SOURCE=1
-        - PYTHON_VER=3.5
-
-    - os: linux
-      python: 3.5
-      env:
-        - LICENSE=1
-        - DEPEND_SOURCE=2
-        - PYTHON_VER=3.5
-
-    - os: linux
-      python: 3.5
-      env:
-        - LICENSE=2
-        - DEPEND_SOURCE=3
-        - PYTHON_VER=3.5
+#    - os: osx
+#      language: generic
+#      env:
+#        - LICENSE=1
+#        - DEPEND_SOURCE=2
+#        - PYTHON_VER=3.6
+#    - os: osx
+#      language: generic
+#      env:
+#        - LICENSE=2
+#        - DEPEND_SOURCE=3
+#        - PYTHON_VER=3.6
+#    - os: osx
+#      language: generic
+#      env:
+#        - LICENSE=1
+#        - DEPEND_SOURCE=1
+#        - PYTHON_VER=3.5
+#    - os: osx
+#      language: generic
+#      env:
+#        - LICENSE=1
+#        - DEPEND_SOURCE=2
+#        - PYTHON_VER=3.5
+#    - os: osx
+#      language: generic
+#      env:
+#        - LICENSE=2
+#        - DEPEND_SOURCE=3
+#        - PYTHON_VER=3.5
+#
+#    - os: linux
+#      python: 3.6
+#      env:
+#        - LICENSE=1
+#        - DEPEND_SOURCE=1
+#        - PYTHON_VER=3.6
+#
+#    - os: linux
+#      python: 3.6
+#      env:
+#        - LICENSE=1
+#        - DEPEND_SOURCE=2
+#        - PYTHON_VER=3.6
+#
+#    - os: linux
+#      python: 3.6
+#      env:
+#        - LICENSE=2
+#        - DEPEND_SOURCE=3
+#        - PYTHON_VER=3.6
+#
+#    - os: linux
+#      python: 3.5
+#      env:
+#        - LICENSE=1
+#        - DEPEND_SOURCE=1
+#        - PYTHON_VER=3.5
+#
+#    - os: linux
+#      python: 3.5
+#      env:
+#        - LICENSE=1
+#        - DEPEND_SOURCE=2
+#        - PYTHON_VER=3.5
+#
+#    - os: linux
+#      python: 3.5
+#      env:
+#        - LICENSE=2
+#        - DEPEND_SOURCE=3
+#        - PYTHON_VER=3.5
 
 before_install:
     # Make sure pip is around (works on > 3.4 which the cookiecutter is)
-  - if [[ "$TRAVIS_OS_NAME" == "osx" && ! $(command -v pip) ]]; then mkdir -p $HOME/bin && ln -s $(which pip3) $HOME/bin/pip && export PATH=$PATH:$HOME/bin; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" && ! $(command -v pip) ]]; echo $PATH; then mkdir -p $HOME/bin && ln -s $(which pip3) $HOME/bin/pip && export PATH=$PATH:$HOME/bin; fi
   # - sudo python -m ensurepip
 
     # Install a few requirements

--- a/.travis.yml
+++ b/.travis.yml
@@ -97,7 +97,8 @@ matrix:
 
 before_install:
     # Make sure pip is around
-  - if [[ "$TRAVIS_OS_NAME" == "osx" && ! $(command -v pip) ]]; then ls -l $(which pip2); ls -l $(which python); mkdir -p $HOME/bin && ln -s $(which pip2) $HOME/bin/pip; fi
+  # - if [[ "$TRAVIS_OS_NAME" == "osx" && ! $(command -v pip) ]]; then ls -l $(which pip2); ls -l $(which python); mkdir -p $HOME/bin && ln -s $(which pip2) $HOME/bin/pip; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" && ! $(command -v pip) ]]; then easy_install pip fi
     # Make sure pip is around (works on > 3.4 which the cookiecutter is)
   # - sudo python -m ensurepip
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -97,7 +97,7 @@ matrix:
 
 before_install:
     # Make sure pip is around
-  - if [[ "$TRAVIS_OS_NAME" == "osx" && ! $(command -v pip) ]]; then echo $(which pip); echo $(which python); mkdir -p $HOME/bin && ln -s $(which pip2) $HOME/bin/pip; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" && ! $(command -v pip) ]]; then echo $(which pip2); echo $(which python); mkdir -p $HOME/bin && ln -s $(which pip2) $HOME/bin/pip; fi
     # Make sure pip is around (works on > 3.4 which the cookiecutter is)
   # - sudo python -m ensurepip
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -125,3 +125,7 @@ after_install:
   - cd docs
   - make html
 
+branches:
+  only:
+  - master
+  - newtravis

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,18 +2,18 @@ language: python
 
 matrix:
   include:
-    - env:
-       - LICENSE=1
-       - DEPEND_SOURCE=1
-       - PYTHON_VER=3.6
-    - env:
-       - LICENSE=1
-       - DEPEND_SOURCE=2
-       - PYTHON_VER=3.6
-    - env:
-       - LICENSE=2
-       - DEPEND_SOURCE=3
-       - PYTHON_VER=3.6
+#    - env:
+#       - LICENSE=1
+#       - DEPEND_SOURCE=1
+#       - PYTHON_VER=3.6
+#    - env:
+#       - LICENSE=1
+#       - DEPEND_SOURCE=2
+#       - PYTHON_VER=3.6
+#    - env:
+#       - LICENSE=2
+#       - DEPEND_SOURCE=3
+#       - PYTHON_VER=3.6
 
     # Extra includes for OSX since python language is not available by default on OSX
     - os: osx
@@ -59,12 +59,14 @@ matrix:
         - LICENSE=1
         - DEPEND_SOURCE=1
         - PYTHON_VER=3.6
+
     - os: linux
       python: 3.6
       env:
         - LICENSE=1
         - DEPEND_SOURCE=2
         - PYTHON_VER=3.6
+
     - os: linux
       python: 3.6
       env:
@@ -78,12 +80,14 @@ matrix:
         - LICENSE=1
         - DEPEND_SOURCE=1
         - PYTHON_VER=3.5
+
     - os: linux
       python: 3.5
       env:
         - LICENSE=1
         - DEPEND_SOURCE=2
         - PYTHON_VER=3.5
+
     - os: linux
       python: 3.5
       env:
@@ -93,7 +97,7 @@ matrix:
 
 before_install:
     # Make sure pip is around (works on > 3.4 which the cookiecutter is)
-  - if [[ $TRAVIS_OS_NAME == 'osx' && ! $(command -v pip) ]]; then mkdir -p $HOME/bin && ln -s $(which pip3) $HOME/bin/pip; fi
+  - if [[ $TRAVIS_OS_NAME == 'osx' && ! $(command -v pip) ]]; then mkdir -p $HOME/bin && ln -s $(which pip3) $HOME/bin/pip && export PATH=$PATH:$HOME/bin; fi
   # - sudo python -m ensurepip
 
     # Install a few requirements

--- a/.travis.yml
+++ b/.travis.yml
@@ -97,7 +97,7 @@ matrix:
 
 before_install:
     # Make sure pip is around
-  - if [[ "$TRAVIS_OS_NAME" == "osx" && ! $(command -v pip) ]]; then mkdir -p $HOME/bin && ln -s $(which pip2) $HOME/bin/pip; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" && ! $(command -v pip) ]]; then echo $(which pip); echo $(which python); mkdir -p $HOME/bin && ln -s $(which pip2) $HOME/bin/pip; fi
     # Make sure pip is around (works on > 3.4 which the cookiecutter is)
   # - sudo python -m ensurepip
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -98,7 +98,7 @@ matrix:
 before_install:
     # Make sure pip is around
   # - if [[ "$TRAVIS_OS_NAME" == "osx" && ! $(command -v pip) ]]; then ls -l $(which pip2); ls -l $(which python); mkdir -p $HOME/bin && ln -s $(which pip2) $HOME/bin/pip; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" && ! $(command -v pip) ]]; then easy_install pip; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" && ! $(command -v pip) ]]; then sudo easy_install pip; fi
     # Make sure pip is around (works on > 3.4 which the cookiecutter is)
   # - sudo python -m ensurepip
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -127,8 +127,3 @@ after_install:
     # Build the docs
   - cd docs
   - make html
-
-branches:
-  only:
-  - master
-  - newtravis

--- a/.travis.yml
+++ b/.travis.yml
@@ -99,7 +99,7 @@ before_install:
     # Make sure pip is around
   # - if [[ "$TRAVIS_OS_NAME" == "osx" && ! $(command -v pip) ]]; then mkdir -p $HOME/bin && ln -s $(which pip2) $HOME/bin/pip; fi
   # - if [[ "$TRAVIS_OS_NAME" == "osx" && ! $(command -v pip) ]]; then easy_install pip --user; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" && ! $(command -v pip) ]]; then bash cihelpers/osx_travis_py_helper.sh; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" && ! $(command -v pip) ]]; then source cihelpers/osx_travis_py_helper.sh; fi
     # Make sure pip is around (works on > 3.4 which the cookiecutter is)
   # - sudo python -m ensurepip
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -98,8 +98,9 @@ matrix:
         - PYTHON_VER=3.5
 
 before_install:
-    # Configure the fact that travis is missing some things
-  - if [[ $TRAVIS_OS_NAME == 'osx' && $(command -v pip) ]]; then ln -s pip3 pip; fi
+    # Make sure pip is around (works on > 3.4 which the cookiecutter is)
+  # - if [[ $TRAVIS_OS_NAME == 'osx' && $(command -v pip) ]]; then ln -s pip3 pip; fi
+  - python -m ensurepip
 
     # Install a few requirements
   - pip install pyyaml cookiecutter

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,86 +22,82 @@ matrix:
         - LICENSE=1
         - DEPEND_SOURCE=1
         - PYTHON_VER=3.6
-#    - os: osx
-#      language: generic
-#      env:
-#        - LICENSE=1
-#        - DEPEND_SOURCE=2
-#        - PYTHON_VER=3.6
-#    - os: osx
-#      language: generic
-#      env:
-#        - LICENSE=2
-#        - DEPEND_SOURCE=3
-#        - PYTHON_VER=3.6
-#    - os: osx
-#      language: generic
-#      env:
-#        - LICENSE=1
-#        - DEPEND_SOURCE=1
-#        - PYTHON_VER=3.5
-#    - os: osx
-#      language: generic
-#      env:
-#        - LICENSE=1
-#        - DEPEND_SOURCE=2
-#        - PYTHON_VER=3.5
-#    - os: osx
-#      language: generic
-#      env:
-#        - LICENSE=2
-#        - DEPEND_SOURCE=3
-#        - PYTHON_VER=3.5
-#
-#    - os: linux
-#      python: 3.6
-#      env:
-#        - LICENSE=1
-#        - DEPEND_SOURCE=1
-#        - PYTHON_VER=3.6
-#
-#    - os: linux
-#      python: 3.6
-#      env:
-#        - LICENSE=1
-#        - DEPEND_SOURCE=2
-#        - PYTHON_VER=3.6
-#
-#    - os: linux
-#      python: 3.6
-#      env:
-#        - LICENSE=2
-#        - DEPEND_SOURCE=3
-#        - PYTHON_VER=3.6
-#
-#    - os: linux
-#      python: 3.5
-#      env:
-#        - LICENSE=1
-#        - DEPEND_SOURCE=1
-#        - PYTHON_VER=3.5
-#
-#    - os: linux
-#      python: 3.5
-#      env:
-#        - LICENSE=1
-#        - DEPEND_SOURCE=2
-#        - PYTHON_VER=3.5
-#
-#    - os: linux
-#      python: 3.5
-#      env:
-#        - LICENSE=2
-#        - DEPEND_SOURCE=3
-#        - PYTHON_VER=3.5
+    - os: osx
+      language: generic
+      env:
+        - LICENSE=1
+        - DEPEND_SOURCE=2
+        - PYTHON_VER=3.6
+    - os: osx
+      language: generic
+      env:
+        - LICENSE=2
+        - DEPEND_SOURCE=3
+        - PYTHON_VER=3.6
+    - os: osx
+      language: generic
+      env:
+        - LICENSE=1
+        - DEPEND_SOURCE=1
+        - PYTHON_VER=3.5
+    - os: osx
+      language: generic
+      env:
+        - LICENSE=1
+        - DEPEND_SOURCE=2
+        - PYTHON_VER=3.5
+    - os: osx
+      language: generic
+      env:
+        - LICENSE=2
+        - DEPEND_SOURCE=3
+        - PYTHON_VER=3.5
+
+    - os: linux
+      python: 3.6
+      env:
+        - LICENSE=1
+        - DEPEND_SOURCE=1
+        - PYTHON_VER=3.6
+
+    - os: linux
+      python: 3.6
+      env:
+        - LICENSE=1
+        - DEPEND_SOURCE=2
+        - PYTHON_VER=3.6
+
+    - os: linux
+      python: 3.6
+      env:
+        - LICENSE=2
+        - DEPEND_SOURCE=3
+        - PYTHON_VER=3.6
+
+    - os: linux
+      python: 3.5
+      env:
+        - LICENSE=1
+        - DEPEND_SOURCE=1
+        - PYTHON_VER=3.5
+
+    - os: linux
+      python: 3.5
+      env:
+        - LICENSE=1
+        - DEPEND_SOURCE=2
+        - PYTHON_VER=3.5
+
+    - os: linux
+      python: 3.5
+      env:
+        - LICENSE=2
+        - DEPEND_SOURCE=3
+        - PYTHON_VER=3.5
 
 before_install:
-    # Make sure pip is around
-  # - if [[ "$TRAVIS_OS_NAME" == "osx" && ! $(command -v pip) ]]; then mkdir -p $HOME/bin && ln -s $(which pip2) $HOME/bin/pip; fi
-  # - if [[ "$TRAVIS_OS_NAME" == "osx" && ! $(command -v pip) ]]; then easy_install pip --user; fi
+    # Make sure pip is around, on OSX Travis we have to do some shenanigans
   - if [[ "$TRAVIS_OS_NAME" == "osx" && ! $(command -v pip) ]]; then source cihelpers/osx_travis_py_helper.sh; fi
-    # Make sure pip is around (works on > 3.4 which the cookiecutter is)
-  # - sudo python -m ensurepip
 
     # Install a few requirements
   - pip install pyyaml cookiecutter

--- a/.travis.yml
+++ b/.travis.yml
@@ -99,8 +99,8 @@ matrix:
 
 before_install:
     # Make sure pip is around (works on > 3.4 which the cookiecutter is)
-  # - if [[ $TRAVIS_OS_NAME == 'osx' && $(command -v pip) ]]; then ln -s pip3 pip; fi
-  - python -m ensurepip
+  # - if [[ $TRAVIS_OS_NAME == 'osx' && ! $(command -v pip) ]]; then ln -s pip3 pip; fi
+  - sudo python -m ensurepip
 
     # Install a few requirements
   - pip install pyyaml cookiecutter

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,82 +22,83 @@ matrix:
         - LICENSE=1
         - DEPEND_SOURCE=1
         - PYTHON_VER=3.6
-#    - os: osx
-#      language: generic
-#      env:
-#        - LICENSE=1
-#        - DEPEND_SOURCE=2
-#        - PYTHON_VER=3.6
-#    - os: osx
-#      language: generic
-#      env:
-#        - LICENSE=2
-#        - DEPEND_SOURCE=3
-#        - PYTHON_VER=3.6
-#    - os: osx
-#      language: generic
-#      env:
-#        - LICENSE=1
-#        - DEPEND_SOURCE=1
-#        - PYTHON_VER=3.5
-#    - os: osx
-#      language: generic
-#      env:
-#        - LICENSE=1
-#        - DEPEND_SOURCE=2
-#        - PYTHON_VER=3.5
-#    - os: osx
-#      language: generic
-#      env:
-#        - LICENSE=2
-#        - DEPEND_SOURCE=3
-#        - PYTHON_VER=3.5
-#
-#    - os: linux
-#      python: 3.6
-#      env:
-#        - LICENSE=1
-#        - DEPEND_SOURCE=1
-#        - PYTHON_VER=3.6
-#
-#    - os: linux
-#      python: 3.6
-#      env:
-#        - LICENSE=1
-#        - DEPEND_SOURCE=2
-#        - PYTHON_VER=3.6
-#
-#    - os: linux
-#      python: 3.6
-#      env:
-#        - LICENSE=2
-#        - DEPEND_SOURCE=3
-#        - PYTHON_VER=3.6
-#
-#    - os: linux
-#      python: 3.5
-#      env:
-#        - LICENSE=1
-#        - DEPEND_SOURCE=1
-#        - PYTHON_VER=3.5
-#
-#    - os: linux
-#      python: 3.5
-#      env:
-#        - LICENSE=1
-#        - DEPEND_SOURCE=2
-#        - PYTHON_VER=3.5
-#
-#    - os: linux
-#      python: 3.5
-#      env:
-#        - LICENSE=2
-#        - DEPEND_SOURCE=3
-#        - PYTHON_VER=3.5
+    - os: osx
+      language: generic
+      env:
+        - LICENSE=1
+        - DEPEND_SOURCE=2
+        - PYTHON_VER=3.6
+    - os: osx
+      language: generic
+      env:
+        - LICENSE=2
+        - DEPEND_SOURCE=3
+        - PYTHON_VER=3.6
+    - os: osx
+      language: generic
+      env:
+        - LICENSE=1
+        - DEPEND_SOURCE=1
+        - PYTHON_VER=3.5
+    - os: osx
+      language: generic
+      env:
+        - LICENSE=1
+        - DEPEND_SOURCE=2
+        - PYTHON_VER=3.5
+    - os: osx
+      language: generic
+      env:
+        - LICENSE=2
+        - DEPEND_SOURCE=3
+        - PYTHON_VER=3.5
+
+    - os: linux
+      python: 3.6
+      env:
+        - LICENSE=1
+        - DEPEND_SOURCE=1
+        - PYTHON_VER=3.6
+
+    - os: linux
+      python: 3.6
+      env:
+        - LICENSE=1
+        - DEPEND_SOURCE=2
+        - PYTHON_VER=3.6
+
+    - os: linux
+      python: 3.6
+      env:
+        - LICENSE=2
+        - DEPEND_SOURCE=3
+        - PYTHON_VER=3.6
+
+    - os: linux
+      python: 3.5
+      env:
+        - LICENSE=1
+        - DEPEND_SOURCE=1
+        - PYTHON_VER=3.5
+
+    - os: linux
+      python: 3.5
+      env:
+        - LICENSE=1
+        - DEPEND_SOURCE=2
+        - PYTHON_VER=3.5
+
+    - os: linux
+      python: 3.5
+      env:
+        - LICENSE=2
+        - DEPEND_SOURCE=3
+        - PYTHON_VER=3.5
 
 before_install:
+    # Make sure pip is around
+  - if [[ "$TRAVIS_OS_NAME" == "osx" && ! $(command -v pip) ]]; then mkdir -p $HOME/bin && ln -s $(which pip2) $HOME/bin/pip; fi
     # Make sure pip is around (works on > 3.4 which the cookiecutter is)
-  - if [[ "$TRAVIS_OS_NAME" == "osx" && ! $(command -v pip) ]]; then echo $PATH; echo $(which pip3); echo $(which pip2); mkdir -p $HOME/bin && ln -s $(which pip3) $HOME/bin/pip && export PATH=$PATH:$HOME/bin; fi
   # - sudo python -m ensurepip
 
     # Install a few requirements

--- a/.travis.yml
+++ b/.travis.yml
@@ -105,6 +105,8 @@ before_install:
     # Install a few requirements
   - pip install pyyaml cookiecutter
 
+  - python -c "help('modules')"
+
     # Build out the cookiecutter from settings
   - python tests/setup_cookiecutter.py default_project $LICENSE $DEPEND_SOURCE
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -97,15 +97,14 @@ matrix:
 
 before_install:
     # Make sure pip is around
-  - if [[ "$TRAVIS_OS_NAME" == "osx" && ! $(command -v pip) ]]; then mkdir -p $HOME/bin && ln -s $(which pip2) $HOME/bin/pip; fi
+  # - if [[ "$TRAVIS_OS_NAME" == "osx" && ! $(command -v pip) ]]; then mkdir -p $HOME/bin && ln -s $(which pip2) $HOME/bin/pip; fi
   # - if [[ "$TRAVIS_OS_NAME" == "osx" && ! $(command -v pip) ]]; then easy_install pip --user; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" && ! $(command -v pip) ]]; then brew install python pip; fi
     # Make sure pip is around (works on > 3.4 which the cookiecutter is)
   # - sudo python -m ensurepip
 
     # Install a few requirements
   - pip install pyyaml cookiecutter
-
-  - python -c "help('modules')"
 
     # Build out the cookiecutter from settings
   - python tests/setup_cookiecutter.py default_project $LICENSE $DEPEND_SOURCE

--- a/.travis.yml
+++ b/.travis.yml
@@ -97,7 +97,7 @@ matrix:
 
 before_install:
     # Make sure pip is around (works on > 3.4 which the cookiecutter is)
-  - if [[ $TRAVIS_OS_NAME == 'osx' && ! $(command -v pip) ]]; then mkdir -p $HOME/bin && ln -s $(which pip3) $HOME/bin/pip && export PATH=$PATH:$HOME/bin; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" && ! $(command -v pip) ]]; then mkdir -p $HOME/bin && ln -s $(which pip3) $HOME/bin/pip && export PATH=$PATH:$HOME/bin; fi
   # - sudo python -m ensurepip
 
     # Install a few requirements

--- a/.travis.yml
+++ b/.travis.yml
@@ -97,7 +97,7 @@ matrix:
 
 before_install:
     # Make sure pip is around (works on > 3.4 which the cookiecutter is)
-  - if [[ "$TRAVIS_OS_NAME" == "osx" && ! $(command -v pip) ]]; echo $PATH; then mkdir -p $HOME/bin && ln -s $(which pip3) $HOME/bin/pip && export PATH=$PATH:$HOME/bin; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" && ! $(command -v pip) ]]; then echo $PATH; echo $(which pip3); echo $(which pip2); mkdir -p $HOME/bin && ln -s $(which pip3) $HOME/bin/pip && export PATH=$PATH:$HOME/bin; fi
   # - sudo python -m ensurepip
 
     # Install a few requirements

--- a/cihelpers/osx_travis_py_helper.sh
+++ b/cihelpers/osx_travis_py_helper.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# Travis decided to remove pip from their OSX images post xcode 7.3
+# Travis official stance: Python package development is not supported in OSX.
+# There is technically a pip2 located in the path, but installing packages through it actually installs to a Python
+# in the Brew cellar, which is NOT the same as the python on the path. So mapping pip to $(which pip2) won't work.
+# Easy install does not work, there is no ensurepip, and short of re-mapping the python to the version in the Cellar
+# (which I don't want to do since I fully expect even that to disappear), I've burned out of ideas.
+# ...
+# SO! This file exists as a helper to set up the pyenv
+# ...
+# SIGH - LNN
+
+# Use PyEnv, dont let brew update EVERYTHING ELSE that we don't need it to
+HOMEBREW_NO_AUTO_UPDATE=1 brew upgrade pyenv
+# Pyenv requires minor revision, get the latest
+PYENV_VERSION=$(pyenv install --list |grep $PYTHON_VER | sed -n "s/^[ \t]*\(${PYTHON_VER}\.*[0-9]*\).*/\1/p" | tail -n 1)
+# Install version
+pyenv install $PYENV_VERSION
+# Use version for this
+pyenv global $PYENV_VERSION
+# Setup up path shims
+eval "$(pyenv init -)"

--- a/{{cookiecutter.repo_name}}/.travis.yml
+++ b/{{cookiecutter.repo_name}}/.travis.yml
@@ -26,7 +26,7 @@ before_install:
   - df -h
   - ulimit -a
 
-    # Install the Python environemt
+    # Install the Python environment
   - source devtools/travis-ci/before_install.sh
   - python -V
 

--- a/{{cookiecutter.repo_name}}/.travis.yml
+++ b/{{cookiecutter.repo_name}}/.travis.yml
@@ -38,7 +38,7 @@ install:
 {% else %}
     # Create test environment for package
   - conda create -n test python=$PYTHON_VER pip pytest pytest-cov
-  - source activate test
+  - conda activate test
 
     # Install pip only modules
   - pip install codecov

--- a/{{cookiecutter.repo_name}}/appveyor.yml
+++ b/{{cookiecutter.repo_name}}/appveyor.yml
@@ -20,6 +20,8 @@ environment:
   {% endif %}
 
 install:
+    # Make sure pip is around
+  - python -m ensurepip
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
   {% if (cookiecutter.dependency_source == 'Prefer conda-forge over the default anaconda channel with pip fallback' or cookiecutter.dependency_source == 'Prefer default anaconda channel with pip fallback') %}
   {%- if cookiecutter.dependency_source == 'Prefer conda-forge over the default anaconda channel with pip fallback' %}

--- a/{{cookiecutter.repo_name}}/devtools/conda-recipe/bld.bat
+++ b/{{cookiecutter.repo_name}}/devtools/conda-recipe/bld.bat
@@ -1,3 +1,3 @@
 # Build the python package, don't let setuptools/pip try to get packages
-"%PYTHON%" setup.py install --no-deps
+"%PYTHON%" setup.py develop --no-deps
 if errorlevel 1 exit 1

--- a/{{cookiecutter.repo_name}}/devtools/conda-recipe/bld.bat
+++ b/{{cookiecutter.repo_name}}/devtools/conda-recipe/bld.bat
@@ -1,3 +1,3 @@
 # Build the python package, don't let setuptools/pip try to get packages
-"%PYTHON%" setup.py develop --no-deps
+pip install . --no-deps
 if errorlevel 1 exit 1

--- a/{{cookiecutter.repo_name}}/devtools/conda-recipe/bld.bat
+++ b/{{cookiecutter.repo_name}}/devtools/conda-recipe/bld.bat
@@ -1,2 +1,3 @@
-"%PYTHON%" setup.py install
+# Build the python package, don't let setuptools/pip try to get packages
+"%PYTHON%" setup.py install --no-deps
 if errorlevel 1 exit 1

--- a/{{cookiecutter.repo_name}}/devtools/conda-recipe/build.sh
+++ b/{{cookiecutter.repo_name}}/devtools/conda-recipe/build.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-# Build the python package
-$PYTHON setup.py install
+# Build the python package, don't let setuptools/pip try to get packages
+$PYTHON setup.py install --no-deps

--- a/{{cookiecutter.repo_name}}/devtools/conda-recipe/build.sh
+++ b/{{cookiecutter.repo_name}}/devtools/conda-recipe/build.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 
 # Build the python package, don't let setuptools/pip try to get packages
-$PYTHON setup.py develop --no-deps
+# $PYTHON setup.py develop --no-deps
+pip install . --no-deps

--- a/{{cookiecutter.repo_name}}/devtools/conda-recipe/build.sh
+++ b/{{cookiecutter.repo_name}}/devtools/conda-recipe/build.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # Build the python package, don't let setuptools/pip try to get packages
-$PYTHON setup.py install --no-deps
+$PYTHON setup.py develop --no-deps

--- a/{{cookiecutter.repo_name}}/devtools/travis-ci/before_install.sh
+++ b/{{cookiecutter.repo_name}}/devtools/travis-ci/before_install.sh
@@ -1,6 +1,8 @@
 # Temporarily change directory to $HOME to install software
 pushd .
 cd $HOME
+# Make sure some level of pip is installed
+python -m ensurepip
 {% if (cookiecutter.dependency_source == 'Prefer conda-forge over the default anaconda channel with pip fallback' or cookiecutter.dependency_source == 'Prefer default anaconda channel with pip fallback') %}
 # Install Miniconda
 if [ "$TRAVIS_OS_NAME" == "osx" ]; then

--- a/{{cookiecutter.repo_name}}/devtools/travis-ci/before_install.sh
+++ b/{{cookiecutter.repo_name}}/devtools/travis-ci/before_install.sh
@@ -26,7 +26,11 @@ bash $MINICONDA -b -p $MINICONDA_HOME
 
 # Configure miniconda
 export PIP_ARGS="-U"
-export PATH=$MINICONDA_HOME/bin:$PATH
+# New to conda >=4.4
+echo ". $MINICONDA_HOME/etc/profile.d/conda.sh" >> ~/.bashrc  # Source the profile.d file
+echo "conda activate" >> ~/.bashrc  # Activate conda
+source ~/.bashrc  # source file to get new commands
+#export PATH=$MINICONDA_HOME/bin:$PATH  # Old way, should not be needed anymore
     {% if cookiecutter.dependency_source == "Prefer conda-forge over the default anaconda channel with pip fallback" %}
 conda config --add channels conda-forge
     {% endif %}


### PR DESCRIPTION
* Change Cookiecutter testing scheme to test all python versions and OS combinations
* Update Travis script to correctly handle their OSX platform missing `pip` after xcode 7.3.
    * After much trial and error, using `brew`->`pyenv` to be done with it. 
    * See notes in the bash source file in the new `cihelpers` folder. 
* Use `--no-deps` when when using conda for packages to prevent pip from installing them
    * Cannot use `python setup.py develop --no-deps` because then conda does not recognize the package installed correctly and cannot execute its `test` block since it won't find the package.