### PR TITLE
Update Conda Meta to host-run

### DIFF
--- a/{{cookiecutter.repo_name}}/devtools/conda-recipe/meta.yaml
+++ b/{{cookiecutter.repo_name}}/devtools/conda-recipe/meta.yaml
@@ -9,7 +9,7 @@ build:
   number: 0
 
 requirements:
-  build:
+  host:
     - python
     - setuptools
 


### PR DESCRIPTION
Closes #38 since the change here and the changes in fixing the tests supersede it.